### PR TITLE
Update PngWriter.hpp

### DIFF
--- a/PngWriter.hpp
+++ b/PngWriter.hpp
@@ -83,7 +83,7 @@ private:
     buffer[(ny-j-1)*nx+i][2] = b;
   }
   
-  void write(char * filename) {
+  void write(const char * filename) {
 
     // note: we completely skip any error handling treatment here for simplicity.
     


### PR DESCRIPTION
warning: ISO C++ forbids converting a string constant to ‘char*’ ( updated the png.write function :) )